### PR TITLE
make tydux-angular compatible with Angular 10

### DIFF
--- a/projects/w11k/tydux-angular/src/lib/TyduxModule.ts
+++ b/projects/w11k/tydux-angular/src/lib/TyduxModule.ts
@@ -37,7 +37,7 @@ export class TyduxModule {
         injector.get(TyduxStore);
     }
 
-    static forRootWithConfig(config: TyduxConfiguration | (() => TyduxConfiguration)): ModuleWithProviders {
+    static forRootWithConfig(config: TyduxConfiguration | (() => TyduxConfiguration)): ModuleWithProviders<TyduxModule> {
         return {
             ngModule: TyduxModule,
             providers: [
@@ -50,7 +50,7 @@ export class TyduxModule {
         };
     }
 
-    static forRootWithoutConfig(): ModuleWithProviders {
+    static forRootWithoutConfig(): ModuleWithProviders<TyduxModule> {
         return {
             ngModule: TyduxModule,
             providers: [


### PR DESCRIPTION
In Angular 10 the generic type parameter of ModuleWithProviders isn't optional anymore. Therefore the current version of tydux-angular isn't compatible with Angular 10. This pull requests adds the generic type parameter.