### PR TITLE
adds documentation on how to test a tydux facade with angular

### DIFF
--- a/doc/testing.md
+++ b/doc/testing.md
@@ -68,3 +68,26 @@ TestBed.configureTestingModule({
   ]
 })
 ```
+
+If you want to test the Tydux facade itself you can use the following pattern
+```typescript
+describe('tydux facade', () => {
+    beforeEach(() => TestBed.configureTestingModule({
+      declarations: [
+        TyduxModule.forRootWithoutConfig()
+      ],
+      providers: [
+        MyService,
+      ],
+    }));
+
+    afterEach(() => {
+      removeGlobalStore();
+    });
+    
+    it('compiles the service', () => {
+        const service: MyService = TestBed.inject(MyService);
+        expect(service).toBeDefined();
+    });
+});
+```


### PR DESCRIPTION
adds a short code snippet on how to setup a facade test.

Since Tydux 14 you are required to clean up the Facade in a `afterEach` or else tydux will throw an Error.
@romanroe  or @sengmann could you please take a look at the code snippet if it is correct?