### PR TITLE
Guard dev mode and devtools against SSR window access

### DIFF
--- a/modules/tydux-angular/package-lock.json
+++ b/modules/tydux-angular/package-lock.json
@@ -6105,7 +6105,7 @@
         },
         "node_modules/@redux-devtools/extension": {
             "version": "3.2.5",
-            "resolved": "http://localhost:4873/@redux-devtools%2fextension/-/extension-3.2.5.tgz",
+            "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.2.5.tgz",
             "integrity": "sha512-UhyDF7WmdnCrN1s++YC4sdQCo0z6YUnoB2eCh15nXDDq3QH1jDju1144UNRU6Nvi4inxhaIum4m9BXVYWVC1ng==",
             "license": "MIT",
             "dependencies": {
@@ -6971,8 +6971,8 @@
         },
         "node_modules/@w11k/tydux": {
             "version": "17.0.0",
-            "resolved": "http://localhost:4873/@w11k%2ftydux/-/tydux-17.0.0.tgz",
-            "integrity": "sha512-HLAgESfc9prYSqliwhhxVtNr6TzlQKYcocMgABqsnvThqB/axQxsKGcaNdCmSGUCws/srNqUgrSzeLpIRPiElg==",
+            "resolved": "https://registry.npmjs.org/@w11k/tydux/-/tydux-17.0.0.tgz",
+            "integrity": "sha512-4nTK9uK//zkModLZ+Dio2sZXncawoPLRM2mOcJPeJ7c3QIF58hCNDZEFYZyoPJfqLueJTsj32kIng6BoViAlsw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@w11k/rx-ninja": "^4.0.0"

--- a/modules/tydux-angular/tydux-angular/src/lib/tydux-angular.module.ts
+++ b/modules/tydux-angular/tydux-angular/src/lib/tydux-angular.module.ts
@@ -1,4 +1,5 @@
-import {APP_INITIALIZER, inject, InjectionToken, ModuleWithProviders, NgModule, Provider} from '@angular/core';
+import {APP_INITIALIZER, inject, InjectionToken, ModuleWithProviders, NgModule, PLATFORM_ID, Provider} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
 import {Reducer, StoreEnhancer} from "redux"
 import {
   createTyduxStore,
@@ -50,11 +51,15 @@ export function factoryTyduxStore(): TyduxStore {
   const configFactory = inject(tyduxModuleConfiguration) ?? {} as TyduxConfiguration;
   const config = typeof configFactory === "function" ? configFactory() : configFactory;
   const initialState = Object.assign({}, config.preloadedState);
+  const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  if (config.developmentMode === undefined && config.environment !== undefined && !config.environment.production) {
-    enableTyduxDevelopmentMode(config);
-  } else if (config.developmentMode === true) {
-    enableTyduxDevelopmentMode(config);
+  // Devtools/development mode must only be enabled in the browser, never during SSR.
+  if (isBrowser) {
+    if (config.developmentMode === undefined && config.environment !== undefined && !config.environment.production) {
+      enableTyduxDevelopmentMode(config);
+    } else if (config.developmentMode === true) {
+      enableTyduxDevelopmentMode(config);
+    }
   }
 
   const tyduxStore = createTyduxStore(initialState, {

--- a/modules/tydux/src/lib/development.ts
+++ b/modules/tydux/src/lib/development.ts
@@ -15,7 +15,7 @@ const defaultTyduxDevModeConfig: TyduxDevModeConfig = {
 };
 
 export function enableTyduxDevelopmentMode(enableOrConfig: boolean | TyduxDevModeConfig = true) {
-    if (devModeConfig === undefined && enableOrConfig && (typeof Window === "function")) {
+    if (devModeConfig === undefined && enableOrConfig && (typeof window !== "undefined")) {
         console.log("enableTyduxDevelopmentMode() called. Tydux is running in the development mode.");
     }
 
@@ -36,7 +36,8 @@ export function isTyduxDevelopmentModeEnabled() {
 }
 
 export function checkDevModeAndCreateDevToolsEnabledComposeFn(options: Partial<EnhancerOptions> = {}) {
-    if (isTyduxDevelopmentModeEnabled()
+    if (typeof window !== "undefined"
+        && isTyduxDevelopmentModeEnabled()
         && devModeConfig!.autoUseDevToolsInDevelopmentMode
         && window.hasOwnProperty(DEV_TOOLS_COMPOSE)) {
 


### PR DESCRIPTION
## Summary

- Gate Tydux development mode activation behind `isPlatformBrowser` in the Angular module so devtools are never enabled during SSR
- Fix `enableTyduxDevelopmentMode` to check `typeof window !== "undefined"` instead of the incorrect `typeof Window === "function"`
- Guard `checkDevModeAndCreateDevToolsEnabledComposeFn` with a `window` existence check before accessing `window.hasOwnProperty`
- Update `package-lock.json` to resolve `@redux-devtools/extension` and `@w11k/tydux` from the public npm registry instead of a local registry

## Testing

- Not run